### PR TITLE
Security: upgrade commons-codec and refresh Maven plugins

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -81,12 +81,12 @@
         <dependency>
             <groupId>commons-codec</groupId>
             <artifactId>commons-codec</artifactId>
-            <version>1.6</version>
+            <version>1.19.0</version>
         </dependency>
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
-            <version>4.11</version>
+            <version>4.13.2</version>
             <scope>test</scope>
         </dependency>
     </dependencies>
@@ -96,7 +96,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>3.8.1</version>
+                <version>3.13.0</version>
                 <configuration>
                     <source>8</source>
                     <target>8</target>
@@ -128,7 +128,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-release-plugin</artifactId>
-                <version>2.5.1</version>
+                <version>3.1.1</version>
                 <configuration>
                     <autoVersionSubmodules>true</autoVersionSubmodules>
                     <useReleaseProfile>false</useReleaseProfile>
@@ -140,7 +140,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-gpg-plugin</artifactId>
-                <version>1.5</version>
+                <version>3.2.8</version>
                 <executions>
                     <execution>
                         <id>sign-artifacts</id>


### PR DESCRIPTION
### Description
Security-focused refresh to address known vulnerabilities and move tooling to supported versions. No functional behavior changes intended; build remains Java 8–compatible (`source`/`target` = 8).

### Changes
- `commons-codec`: **1.6 → 1.19.0**
- `junit` (test): **4.11 → 4.13.2**
- `maven-compiler-plugin`: **3.8.1 → 3.13.0**
- `maven-release-plugin`: **2.5.1 → 3.1.1**
- `maven-gpg-plugin`: **1.5 → 3.2.8**
